### PR TITLE
PagerDuty Service Broker for PCF Updates for version 1.0.0

### DIFF
--- a/docs-book/master_middleman/source/subnavs/pagerduty-service-broker_subnav.erb
+++ b/docs-book/master_middleman/source/subnavs/pagerduty-service-broker_subnav.erb
@@ -5,7 +5,7 @@
   <div class="nav-content">
     <ul>
       <li>
-        <a id='home-nav-link' href="/pagerduty-service-broker/index.html">PagerDuty Service Broker for PCF</a>
+        <a id='home-nav-link' href="/pagerduty-service-broker/index.html">PagerDuty Service Broker for PCF (Beta)</a>
       </li>
 
       <li>

--- a/docs-book/master_middleman/source/subnavs/pagerduty-service-broker_subnav.erb
+++ b/docs-book/master_middleman/source/subnavs/pagerduty-service-broker_subnav.erb
@@ -5,7 +5,7 @@
   <div class="nav-content">
     <ul>
       <li>
-        <a id='home-nav-link' href="/pagerduty-service-broker/index.html">PagerDuty Service Broker for PCF (Beta)</a>
+        <a id='home-nav-link' href="/pagerduty-service-broker/index.html">PagerDuty Service Broker for PCF</a>
       </li>
 
       <li>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -41,11 +41,11 @@ The following table provides version and version-support information about Pager
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.0.0</td>
+        <td>v1.0.1</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>August 8, 2018</td>
+        <td>August 21, 2018</td>
     </tr>
     <tr>
         <td>Software component version</td>
@@ -53,11 +53,11 @@ The following table provides version and version-support information about Pager
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v1.9.x</td>
+        <td>v2.0.x, v2.1.x, and v2.2.x</td>
     </tr>
     <tr>
-        <td>Compatible Elastic Runtime version(s)</td>
-        <td>v1.9.x</td>
+        <td>Compatible Pivotal Application Service version(s)</td>
+        <td>v2.0.x, v2.1.x, and v2.2.x</td>
     </tr>
     <tr>
         <td>IaaS support</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -49,7 +49,7 @@ The following table provides version and version-support information about Pager
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>PagerDuty Service Broker for PCF v1.0.0</td>
+        <td>PagerDuty Service Broker for PCF v1.0.1</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -13,6 +13,12 @@ owner: Partners
      }
 </style>
 
+<p class="note warning">
+<strong>IMPORTANT: </strong>
+PagerDuty Service Broker for Pivotal Cloud Foundry (PCF) tile is currently in beta and is intended for evaluation and test purposes only.
+Do not use this product in a PCF production environment.
+</p>
+
 This documentation describes PagerDuty Service Broker for Pivotal Cloud Foundry (PCF). PagerDuty Service Broker for PCF enables developers to integrate their PCF apps with PagerDuty’s incident management platform.
 
 ## <a id='overview'></a>Overview
@@ -41,15 +47,15 @@ The following table provides version and version-support information about Pager
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.0.1</td>
+        <td>v1.0.2</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>August 21, 2018</td>
+        <td>August 29, 2018</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>PagerDuty Service Broker for PCF v1.0.1</td>
+        <td>PagerDuty Service Broker for PCF v1.0.2</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
@@ -64,6 +70,11 @@ The following table provides version and version-support information about Pager
         <td>AWS, Azure</td>
     </tr>
 </table>
+
+<p class="note warning">
+<strong>IMPORTANT: </strong>
+v1.0.2 is a major release. Upgrades from PagerDuty Service Broker for PCF v0.0.2 are not supported. If you previously installed PagerDuty Service Broker for PCF v0.0.2, uninstall it and install the latest version.
+</p>
 
 ## <a id="reqs"></a>Requirements
 

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: PagerDuty Service Broker for PCF (Beta)
+title: PagerDuty Service Broker for PCF
 owner: Partners
 ---
 <style>
@@ -13,27 +13,23 @@ owner: Partners
      }
 </style>
 
-<p class="note warning">
-<strong>IMPORTANT: </strong>
-PagerDuty Service Broker for Pivotal Cloud Foundry (PCF) tile is currently in beta and is intended for evaluation and test purposes only.
-Do not use this product in a PCF production environment.
-</p>
-
-This documentation describes PagerDuty Service Broker for Pivotal Cloud Foundry (PCF). PagerDuty Service Broker for PCF enables developers to integrate their PCF apps with PagerDuty's incident management platform.
+This documentation describes PagerDuty Service Broker for Pivotal Cloud Foundry (PCF). PagerDuty Service Broker for PCF enables developers to integrate their PCF apps with PagerDuty’s incident management platform.
 
 ## <a id='overview'></a>Overview
 
-PagerDuty Service Broker for PCF registers a service broker with PCF and exposes its service plans on the Marketplace. Developers can then create service plan instances using Apps Manager or the Cloud Foundry Command
-Line Interface (cf CLI) and bind them to their apps. This lets developers manage incidents with their PCF apps using PagerDuty.
-
-See [Using PagerDuty Service Broker for PCF](./using.html).
+PagerDuty Service Broker for PCF registers a service broker with PCF and exposes its service plans on the Marketplace. Developers can then create service plan instances using Apps Manager or the Cloud Foundry Command Line Interface (cf CLI) and bind them to their apps. This lets developers to automatically provision a team, users, escalation policies, service and manage incidents with their PCF apps using PagerDuty.
 
 ## <a id='features'></a>Key&nbsp;Features
 
-PagerDuty Service Broker for PCF includes the following key features:
+PagerDuty Service Broker for PCF includes the following key features: 
 
-* The ability to manage PCF app incidents with PagerDuty's incident management platform
-* Documentation to integrate popular PCF services with PagerDuty
+* The ability to manage PCF app incidents with PagerDuty’s incident management platform
+* PagerDuty Team Provisioning - Provisions a PagerDuty team based on the Pivotal Org and Space name of the Pivotal service or App that is being bound to 
+* PagerDuty User Provisioning 
+  * Multiple Pivotal users can be uploaded during the binding process (via JSON file)
+  * Pivotal Users can also be automatically created based on the Pivotal Org Space's team members 
+* PagerDuty Service Provisioning - Users automatically have a service created to enable easy connectivity to any monitoring tools
+* PagerDuty Escalation Policy Provisioning - users automatically have an Escalation Policy that has a simple escalation process  based on the Pivotal users provisioned during the User and Team provisioning step
 
 ## <a id="snapshot"></a>Product Snapshot
 
@@ -45,15 +41,15 @@ The following table provides version and version-support information about Pager
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v0.0.2</td>
+        <td>v1.0.0</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>May 10, 2017</td>
+        <td>August 8, 2018</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>PagerDuty Service Broker for PCF v0.0.2</td>
+        <td>PagerDuty Service Broker for PCF v1.0.0</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: PagerDuty Service Broker for PCF
+title: PagerDuty Service Broker for PCF (Beta)
 owner: Partners
 ---
 <style>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -3,9 +3,9 @@ title: Release Notes for PagerDuty Service Broker for PCF
 owner: Partners
 ---
 
-### v1.0.1
+### v1.0.2
 
-**Release Date:** Aug 21, 2018
+**Release Date:** Aug 29, 2018
 
 Features included in this release:
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -2,6 +2,20 @@
 title: Release Notes for PagerDuty Service Broker for PCF
 owner: Partners
 ---
+
+### v1.0.0
+
+**Release Date:** Aug 8, 2018
+
+Features included in this release:
+
+* The ability to manage PCF app incidents with PagerDuty’s incident management platform
+* PagerDuty Team Provisioning 
+* PagerDuty User Provisioning 
+* PagerDuty Service Provisioning 
+* PagerDuty Escalation Policy Provisioning 
+
+
 ### v0.0.2
 
 **Release Date:** May 10, 2017

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -3,9 +3,9 @@ title: Release Notes for PagerDuty Service Broker for PCF
 owner: Partners
 ---
 
-### v1.0.0
+### v1.0.1
 
-**Release Date:** Aug 8, 2018
+**Release Date:** Aug 21, 2018
 
 Features included in this release:
 

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -37,3 +37,16 @@ This topic describes how to use PagerDuty Service Broker for Pivotal Cloud Found
     <pre class="terminal">
     $ cf env APP-NAME
     </pre>
+
+##<a id='team-provisioning'></a> Team Provisioning
+
+When adding the PagerDuty service to your Pivotal app, it will automatically provision a PagerDuty team utilizing the Space Name and your Org Name of your Pivotal environment. Additionally, when adding your application to your Pivotal app, it will create a PagerDuty Escalation Policy and Service for that new team.
+
+##<a id='user-provisioning'></a> User Provisioning
+
+User Provisioning can be accomplished in two ways: 
+
+* Using existing users already members of your Pivotal space 
+* Manually entering users 
+
+If the user does not have an existing account in PagerDuty and they are added during the Pivotal user provisioning process, the user will consume a PagerDuty license.


### PR DESCRIPTION
### v1.0.0

**Release Date:** Aug 8, 2018

Features included in this release:

* The ability to manage PCF app incidents with PagerDuty’s incident management platform
* PagerDuty Team Provisioning 
* PagerDuty User Provisioning 
* PagerDuty Service Provisioning 
* PagerDuty Escalation Policy Provisioning 
