### PR TITLE
Upgrade stemcell to ubuntu xenial 250 25 v1.2.0

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -3,11 +3,6 @@ title: PagerDuty Service Broker for PCF
 owner: Partners
 ---
 
-<p class="note warning"><strong> WARNING:</strong>
-This tile requires a Trusty stemcell.
-The end-of-life date for Ubuntu Trusty is April 2019.
-If a security vulnerability is found on this stemcell after April, it will not be fixed.</p>
-
 This documentation describes PagerDuty Service Broker for Pivotal Cloud Foundry (PCF).
 PagerDuty Service Broker for PCF enables developers to integrate their PCF apps with PagerDuty's incident management platform.
 
@@ -39,15 +34,15 @@ The following table provides version and version-support information about Pager
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.1.2</td>
+        <td>v1.2.0</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>October 1, 2018</td>
+        <td>April 22, 2019</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>PagerDuty Service Broker for PCF v1.1.2</td>
+        <td>PagerDuty Service Broker for PCF v1.2.0</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
@@ -59,7 +54,7 @@ The following table provides version and version-support information about Pager
     </tr>
     <tr>
        <td>BOSH stemcell version</td>
-       <td>Ubuntu Trusty</td>
+       <td>Ubuntu Xenial</td>
     </tr>
     <tr>
         <td>IaaS support</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -38,7 +38,7 @@ The following table provides version and version-support information about Pager
     </tr>
     <tr>
         <td>Release date</td>
-        <td>April 22, 2019</td>
+        <td>April 23, 2019</td>
     </tr>
     <tr>
         <td>Software component version</td>
@@ -46,11 +46,11 @@ The following table provides version and version-support information about Pager
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v2.0.x, v2.1.x, and v2.2.x</td>
+        <td>v2.2.x, 2.3.x, 2.4.x, and v2.5.x</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service version(s)</td>
-        <td>v2.0.x, v2.1.x, and v2.2.x</td>
+        <td>v2.2.x, 2.3.x, 2.4.x, and v2.5.x</td>
     </tr>
     <tr>
        <td>BOSH stemcell version</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -5,7 +5,7 @@ owner: Partners
 
 ## <a id='1-2-0'></a> v1.2.0
 
-**Release Date:** April 22, 2019
+**Release Date:** April 23, 2019
 
 Features included in this release:
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -3,6 +3,14 @@ title: Release Notes for PagerDuty Service Broker for PCF
 owner: Partners
 ---
 
+## <a id='1-2-0'></a> v1.2.0
+
+**Release Date:** April 22, 2019
+
+Features included in this release:
+
+* Upgrade stemcell to Ubuntu Xenial 250.25.
+
 ## <a id='1-1-2'></a> v1.1.2
 
 **Release Date:** October 1, 2018


### PR DESCRIPTION
Upgrade stemcell to Ubuntu Xenial 250.25 (end of life for Trusty)